### PR TITLE
Make synchronizing to iCloud optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The plugin's JavaScript functions are called after creating the plugin object th
 
 ### iCloud keychain enabled
 
-iCloud keychain synchonizing is enabled, so the keychain will be mirrored across all devices *if* the user is signed in to iCloud (Settings > iCloud) and has iCloud keychain turned on (Settings > iCloud > Keychain)
+iCloud keychain synchonizing is enabled by default, so the keychain will be mirrored across all devices *if* the user is signed in to iCloud (Settings > iCloud) and has iCloud keychain turned on (Settings > iCloud > Keychain). It is possible to disable synchronizing entries to iCloud when setting keys.
 
 ### Usage
         
@@ -68,8 +68,9 @@ kc.getForKey(successCallback, failureCallback, 'key', 'servicename');
  @param key the key to set
  @param servicename the servicename to use
  @param value the value to set
+ @param sync if the entry should be synchronized to iCloud or not (optional, defaults to true)
  */
-kc.setForKey(successCallback, failureCallback, 'key', 'servicename', 'value');
+kc.setForKey(successCallback, failureCallback, 'key', 'servicename', 'value', sync);
 
 /*
  Removes a value for a key and servicename.

--- a/src/ios/CDVKeychain.m
+++ b/src/ios/CDVKeychain.m
@@ -63,9 +63,14 @@
             NSString* key = [arguments objectAtIndex:0];
             NSString* serviceName = [arguments objectAtIndex:1];
             NSString* value = [arguments objectAtIndex:2];
+            BOOL sync = true;
+            if ([arguments count] >= 4) {
+              sync = [[arguments objectAtIndex:3] boolValue];
+            }
+
             NSError* error = nil;
-            
-            BOOL stored = [SFHFKeychainUtils storeUsername:key andPassword:value forServiceName:serviceName updateExisting:YES error:&error];
+
+            BOOL stored = [SFHFKeychainUtils storeUsername:key andPassword:value forServiceName:serviceName updateExisting:YES sync:sync error:&error];
             if (stored && error == nil) {
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
             } else {

--- a/src/ios/SFHFKeychainUtils/SFHFKeychainUtils.h
+++ b/src/ios/SFHFKeychainUtils/SFHFKeychainUtils.h
@@ -35,7 +35,7 @@
 }
 
 + (NSString *) getPasswordForUsername: (NSString *) username andServiceName: (NSString *) serviceName error: (NSError **) error;
-+ (BOOL) storeUsername: (NSString *) username andPassword: (NSString *) password forServiceName: (NSString *) serviceName updateExisting: (BOOL) updateExisting error: (NSError **) error;
++ (BOOL) storeUsername: (NSString *) username andPassword: (NSString *) password forServiceName: (NSString *) serviceName updateExisting: (BOOL) updateExisting sync: (BOOL) sync error: (NSError **) error;
 + (BOOL) deleteItemForUsername: (NSString *) username andServiceName: (NSString *) serviceName error: (NSError **) error;
 
 @end

--- a/src/ios/SFHFKeychainUtils/SFHFKeychainUtils.m
+++ b/src/ios/SFHFKeychainUtils/SFHFKeychainUtils.m
@@ -79,7 +79,7 @@ static NSString *SFHFKeychainUtilsErrorDomain = @"SFHFKeychainUtilsErrorDomain";
                         kSecClassGenericPassword,
                         username,
                         serviceName,
-                        kCFBooleanTrue,
+                        kSecAttrSynchronizableAny,
                         nil];
     
     NSMutableDictionary *query = [[NSMutableDictionary alloc] initWithObjects: objects forKeys: keys];
@@ -152,8 +152,8 @@ static NSString *SFHFKeychainUtilsErrorDomain = @"SFHFKeychainUtilsErrorDomain";
     return password;
 }
 
-+ (BOOL) storeUsername: (NSString *)username andPassword: (NSString *)password forServiceName: (NSString *)serviceName updateExisting: (BOOL)updateExisting error: (NSError **)error {
-    
++ (BOOL) storeUsername: (NSString *)username andPassword: (NSString *)password forServiceName: (NSString *)serviceName updateExisting: (BOOL)updateExisting sync: (BOOL)sync error: (NSError **)error {
+
     if (!username || !password || !serviceName) {
         if (error != nil) {
             *error = [NSError errorWithDomain: SFHFKeychainUtilsErrorDomain code: -2000 userInfo: nil];
@@ -211,12 +211,12 @@ static NSString *SFHFKeychainUtilsErrorDomain = @"SFHFKeychainUtilsErrorDomain";
                                 serviceName,
                                 serviceName,
                                 username,
-                                kCFBooleanTrue,
+                                kSecAttrSynchronizableAny,
                                 nil];
             
             NSDictionary *query = [[NSDictionary alloc] initWithObjects: objects forKeys: keys];
-            
-            status = SecItemUpdate((__bridge CFDictionaryRef) query, (__bridge CFDictionaryRef) [NSDictionary dictionaryWithObject: [password dataUsingEncoding: NSUTF8StringEncoding] forKey: (__bridge NSString *) kSecValueData]);
+
+            status = SecItemUpdate( (__bridge CFDictionaryRef) query, (__bridge CFDictionaryRef) [NSDictionary dictionaryWithObject: [password dataUsingEncoding: NSUTF8StringEncoding] forKey: (__bridge NSString *) kSecValueData]);
         }
     }
     else {
@@ -238,7 +238,7 @@ static NSString *SFHFKeychainUtilsErrorDomain = @"SFHFKeychainUtilsErrorDomain";
                             serviceName,
                             username,
                             [password dataUsingEncoding: NSUTF8StringEncoding],
-                            kCFBooleanTrue,
+                            sync ? kCFBooleanTrue : kCFBooleanFalse,
                             nil];
         
         NSDictionary *query = [[NSDictionary alloc] initWithObjects: objects forKeys: keys];
@@ -259,7 +259,7 @@ static NSString *SFHFKeychainUtilsErrorDomain = @"SFHFKeychainUtilsErrorDomain";
     return YES;
 }
 
-+ (BOOL) deleteItemForUsername: (NSString *) username andServiceName: (NSString *) serviceName error: (NSError **) error 
++ (BOOL) deleteItemForUsername: (NSString *) username andServiceName: (NSString *) serviceName error: (NSError **) error
 {
     if (!username || !serviceName) 
     {

--- a/www/keychain.js
+++ b/www/keychain.js
@@ -30,9 +30,12 @@ Keychain.prototype.getForKey = function(successCallback, failureCallback, key, s
 	exec(successCallback, failureCallback, this.serviceName, "getForKey", [key, servicename]);
 }
 
-Keychain.prototype.setForKey = function(successCallback, failureCallback, key, servicename, value)
+Keychain.prototype.setForKey = function(successCallback, failureCallback, key, servicename, value, sync)
 {
-	exec(successCallback, failureCallback, this.serviceName, "setForKey", [key, servicename, value]);
+	if(typeof sync === 'undefined') {
+		sync = true;
+	}
+	exec(successCallback, failureCallback, this.serviceName, "setForKey", [key, servicename, value, sync]);
 }
 
 Keychain.prototype.removeForKey = function(successCallback, failureCallback, key, servicename)


### PR DESCRIPTION
This adds an option to set `kSecAttrSynchronizable` to false when adding new entries. This is needed for storing data that should not be backed up to iCloud.

New behavior:

 * Creating new entries: kSecAttrSynchronizable is now optional.
 * Querying for existing values: returns value regardless of `kSecAttrSynchronizable` (previously restricted to true).
 * Deleting existing values: deletes value regardless of `kSecAttrSynchronizable` (previously restricted to true). 
 * Updating existing values: existing entry is updated regardless of the old `kSecAttrSynchronizable` value, but it is not updated to the specified value yet.

Related to #23.

